### PR TITLE
Pick jester from crewmates only

### DIFF
--- a/Jester/GameEventListener.cs
+++ b/Jester/GameEventListener.cs
@@ -108,7 +108,7 @@ namespace Impostor.Plugins.Example.Handlers
                 gameplayers.Add(player);
                 if (player.Character.PlayerInfo.IsImpostor == false)
                 {
-                    crewmates.add(player)
+                    crewmates.add(player);
                 }
             }
             int r = rnd.Next(crewmates.Count);

--- a/Jester/GameEventListener.cs
+++ b/Jester/GameEventListener.cs
@@ -102,18 +102,24 @@ namespace Impostor.Plugins.Example.Handlers
         private async Task AssignJester(IPlayerSetStartCounterEvent e)
         {
             List<IClientPlayer> gameplayers = new List<IClientPlayer>();
+            List<IClientPlayer> crewmates = new List<IClientPlayer>();
             foreach (var player in e.Game.Players)
             {
                 gameplayers.Add(player);
+                if (player.Character.PlayerInfo.IsImpostor == false)
+                {
+                    crewmates.add(player)
+                }
             }
-            int r = rnd.Next(gameplayers.Count);
+            int r = rnd.Next(crewmates.Count);
+            
 
             JesterGame jgame = JesterGames[e.Game.Code];
-            jgame.JesterClientId = gameplayers[r].Client.Id;
-            jgame.Jestername = gameplayers[r].Character.PlayerInfo.PlayerName;
+            jgame.JesterClientId = crewmates[r].Client.Id;
+            jgame.Jestername = crewmates[r].Character.PlayerInfo.PlayerName;
             JesterGames[e.Game.Code] = jgame;
 
-            await ServerSendChatToPlayerAsync($"You're the JESTER! (unless you'll be an imposter)", gameplayers[r].Character).ConfigureAwait(false);
+            await ServerSendChatToPlayerAsync($"You're the JESTER! (unless you'll be an imposter)", crewmates[r].Character).ConfigureAwait(false);
             _logger.LogInformation($"- {JesterGames[e.Game.Code].Jestername} is probably the jester.");    
         }
 

--- a/Jester/GameEventListener.cs
+++ b/Jester/GameEventListener.cs
@@ -108,7 +108,7 @@ namespace Impostor.Plugins.Example.Handlers
                 gameplayers.Add(player);
                 if (player.Character.PlayerInfo.IsImpostor == false)
                 {
-                    crewmates.add(player);
+                    crewmates.Add(player);
                 }
             }
             int r = rnd.Next(crewmates.Count);


### PR DESCRIPTION
Made a small change to pick jester from crewmates only, simply by picking it from a list of players that are not impostor (cf code changes)
I didn't know if the gameplayers list was used somewhere else in the code, so i just kept it where it was.
